### PR TITLE
Update ContaoPageContextInitializer.php

### DIFF
--- a/src/Request/ContaoPageContextInitializer.php
+++ b/src/Request/ContaoPageContextInitializer.php
@@ -116,6 +116,7 @@ final class ContaoPageContextInitializer implements PageContextInitializer
         $this->framework->initialize();
         $this->initializeUserLoggedInConstants();
         $this->initializeGlobals($context);
+        $request->attributes->set('pageModel', $context->page());
         $this->initializeLocale($context, $request);
         $this->initializeStaticUrls();
         $this->initializePageLayout($context);


### PR DESCRIPTION
This should fix some problems in MetaModels, 'cause Contao add a pageModels to the request which is missing for example in MetaModels and so some AJAX calls fail.